### PR TITLE
Make a few edits to the package description and documentation

### DIFF
--- a/docs/_index.md
+++ b/docs/_index.md
@@ -1,11 +1,12 @@
 ---
-title: Cockroach DB Cloud
-meta_desc: Provides an overview of the Cockroach DB Provider for Pulumi.
+title: CockroachDB Cloud
+meta_desc: Provides an overview of the CockroachDB provider for Pulumi.
 layout: package
 ---
 
-The Cockroach provider for Pulumi can be used to provision any of the cloud resources available in [Cockroach DB](https://www.cockroachlabs.com) or a self hosted Cockroach DB instance
-The Cockroach provider must be configured with credentials to deploy and update resources in Cockroach DB.
+The Cockroach provider for Pulumi can be used to provision any of the cloud resources available in [CockroachDB](https://www.cockroachlabs.com) or a self hosted CockroachDB instance.
+
+The Cockroach provider must be configured with credentials to deploy and update resources in CockroachDB.
 
 ## Example
 
@@ -16,7 +17,7 @@ The Cockroach provider must be configured with credentials to deploy and update 
 import * as cockroach from "@lbrlabs/pulumi-cockroach";
 
 const cluster = new cockroach.Cluster("example", {
-  cloudProvider: "aws",
+  cloudProvider: "AWS",
   name: "cockroach-provider-ts",
   regions: [
     {
@@ -34,7 +35,7 @@ import lbrlabs_pulumi_cockroach as cockroach
 
 cluster = cockroach.Cluster(
     "example",
-    cloud_provider="aws",
+    cloud_provider="AWS",
     name="cockroach-provider-py",
 )
 ```

--- a/docs/_index.md
+++ b/docs/_index.md
@@ -19,14 +19,14 @@ import * as cockroach from "@lbrlabs/pulumi-cockroach";
 const cluster = new cockroach.Cluster("example", {
     cloudProvider: "AWS",
     name: "cockroach-provider-ts",
-    serverless: {
-      spendLimit: 0,
-    },
     regions: [
         {
             name: "us-west-2",
         },
     ],
+    serverless: {
+      spendLimit: 0,
+    },
 });
 ```
 
@@ -40,6 +40,14 @@ cluster = cockroach.Cluster(
     "example",
     cloud_provider="AWS",
     name="cockroach-provider-py",
+    regions=[
+        cockroach.ClusterRegionArgs(
+            name="us-west-2",
+        ),
+    ],
+    serverless=cockroach.ClusterServerlessArgs(
+        spend_limit=0,
+    ),
 )
 ```
 

--- a/docs/_index.md
+++ b/docs/_index.md
@@ -17,13 +17,16 @@ The Cockroach provider must be configured with credentials to deploy and update 
 import * as cockroach from "@lbrlabs/pulumi-cockroach";
 
 const cluster = new cockroach.Cluster("example", {
-  cloudProvider: "AWS",
-  name: "cockroach-provider-ts",
-  regions: [
-    {
-      name: "us-west-2",
+    cloudProvider: "AWS",
+    name: "cockroach-provider-ts",
+    serverless: {
+      spendLimit: 0,
     },
-  ],
+    regions: [
+        {
+            name: "us-west-2",
+        },
+    ],
 });
 ```
 

--- a/docs/installation-configuration.md
+++ b/docs/installation-configuration.md
@@ -59,4 +59,4 @@ $ export COCKROACH_API_KEY=<COCKROACH_API_KEY>
 
 ## Configuration Options
 
-Use `pulumi config set cockroach:<option>` or pass options to the [constructor of `new cockroach.Provider`]({{< relref "/registry/packages/cockroach/api-docs/provider" >}}).
+Use `pulumi config set cockroach:<option>` or pass options to the [constructor of `new cockroach.Provider`](/registry/packages/cockroach/api-docs/provider/).

--- a/docs/installation-configuration.md
+++ b/docs/installation-configuration.md
@@ -1,6 +1,6 @@
 ---
-title: Cockroach Installation & Configuration
-meta_desc: Information on how to install the Cockrach provider.
+title: CockroachDB Cloud Installation & Configuration
+meta_desc: Provides an overview on how to configure credentials for the CockroachDB provider.
 layout: package
 ---
 
@@ -25,11 +25,11 @@ Replace the version string with your desired version.
 
 ## Setup
 
-To provision resources with the Pulumi Cockroach provider, you need to have Cockorach credentials. 
+To provision resources with the Pulumi Cockroach provider, you need to have Cockroach credentials. 
 
 ### Set environment variables
 
-Once you have provisioned these credentials, you can set environment variables to provision resources in Cockorach:
+Once you have provisioned these credentials, you can set environment variables to provision resources in Cockroach:
 
 {{< chooser os "linux,macos,windows" >}}
 {{% choosable os linux %}}

--- a/provider/cmd/pulumi-resource-cockroach/schema.json
+++ b/provider/cmd/pulumi-resource-cockroach/schema.json
@@ -1,7 +1,7 @@
 {
     "name": "cockroach",
     "displayName": "CockroachDB",
-    "description": "A Pulumi package to create and managed cockroach db resources in Pulumi programs.",
+    "description": "A Pulumi package for creating and managing CockroachDB cloud resources.",
     "keywords": [
         "pulumi",
         "cockroach"


### PR DESCRIPTION
Makes a few minor edits to fix the provider name, a few typos, and make terminology more consistent with other packages. 

Also adjusts the examples to use uppercase values for the `cloudProvider` param and add a setting for the cluster plan type, as these failed for me when I ran them as written.