### PR TITLE
Fix a broken link

### DIFF
--- a/docs/installation-configuration.md
+++ b/docs/installation-configuration.md
@@ -10,7 +10,7 @@ The Pulumi Cockroach provider is available as a package in all Pulumi languages:
 
 * JavaScript/TypeScript: [`@lbrlabs/pulumi-cockroach`](https://www.npmjs.com/package/@lbrlabs/pulumi-cockroach)
 * Python: [`lbrlabs_pulumi_cockroach`](https://pypi.org/project/lbrlabs-pulumi-cockroach/)
-* Go: [`github.com/lbrlabs/pulumi-cockroach/sdk/go/cockroach`](https://pkg.go.dev/github.com/lbrlabs/pulumi-cockroach/sdk)
+* Go: [`github.com/lbrlabs/pulumi-cockroach/sdk/go/cockroach`](https://github.com/lbrlabs/pulumi-cockroach)
 * .NET: [`Lbrlabs.PulumiPackage.Cockroach`](https://www.nuget.org/packages/Lbrlabs.PulumiPackage.Cockroach)
 
 ### Provider Binary


### PR DESCRIPTION
Updates the Go SDK link to point to the top level of the repo. (It currently 404s.)